### PR TITLE
Disambiguation for THPS1+2 EGS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-asr = { git = "https://github.com/LiveSplit/asr", branch = "master", features = ["signature"] }
+# asr = { git = "https://github.com/LiveSplit/asr", branch = "master", features = ["signature"] }
+
+asr = { path = "../asr", features = ["signature", "alloc"] }
 once_cell = "1.18.0"
 
 [lib]


### PR DESCRIPTION
Process listing released for ASR maybe a month ago, so it's probably safe to merge this now.